### PR TITLE
Add allowed actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added: short-hand method for getting allowed actions
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [1.1.0]

--- a/docs/components/policy.md
+++ b/docs/components/policy.md
@@ -111,6 +111,24 @@ actions_policy.read.allowed? # => true
 actions_policy.write.allowed? # ... depends on `admin?` result
 ```
 
+In order to get all actions do:
+
+```ruby
+policy = UserPolicy.new(user, current_user)
+actions_policy = policy.actions_policy
+
+actions_policy.actions
+```
+
+In order to get all only allowed action names do:
+
+```ruby
+policy = UserPolicy.new(user, current_user)
+actions_policy = policy.actions_policy
+
+actions_policy.allowed_action_names
+```
+
 ## Usage of Policy#attribute
 
 Suppose we have policy like this:
@@ -158,6 +176,16 @@ attributes_policy = policy.attributes_policy
 attributes_policy.email.allowed_to?(:change) # => false - no such rule
 attributes_policy.email.readable? # same as `allowed_to?(:read)`
 attributes_policy.email.writable? # same as `allowed_to?(:write)`
+```
+
+In order to get all allowed attributes do:
+
+```ruby
+policy = UserPolicy.new(user, current_user)
+attributes_policy = policy.attributes_policy
+
+readable_attributes = attributes_policy.all_allowed_to(:read)
+writable_attributes = attributes_policy.all_allowed_to(:write)
 ```
 
 ## Usage of Policy#protected_resource

--- a/lib/resource_policy/policy/actions_policy/actions_policy_model.rb
+++ b/lib/resource_policy/policy/actions_policy/actions_policy_model.rb
@@ -18,6 +18,14 @@ module ResourcePolicy
           policy_item(method_name.to_sym)
         end
 
+        def actions
+          config.actions.keys.map { |name| policy_item(name.to_sym) }
+        end
+
+        def allowed_action_names
+          actions.select(&:allowed?).map(&:name)
+        end
+
         def respond_to_missing?(method_name, *args)
           config.actions.key?(method_name.to_sym) || super
         end

--- a/spec/lib/resource_policy/policy/actions_policy/actions_policy_model_spec.rb
+++ b/spec/lib/resource_policy/policy/actions_policy/actions_policy_model_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::ResourcePolicy:: Policy::ActionsPolicy::ActionsPolicyModel do
+  subject(:actions_policy_model) { described_class.new(model_instance) }
+
+  let(:policy_model) do
+    Class.new do
+      include ResourcePolicy::Policy
+
+      policy do |c|
+        c.action(:create).allowed
+        c.action(:read).allowed
+        c.action(:forbidden_action).allowed(if: :force_not_allowed)
+      end
+
+      def force_not_allowed
+        false
+      end
+    end
+  end
+
+  let(:model_instance) { policy_model.new }
+
+  describe '#actions' do
+    subject(:actions) { actions_policy_model.actions }
+
+    it 'returns actions' do
+      expect(actions).to all be_a(::ResourcePolicy::Policy::ActionsPolicy::ActionPolicy)
+    end
+
+    it 'returns actions with correct names' do
+      expect(actions.map(&:name)).to contain_exactly(:create, :read, :forbidden_action)
+    end
+  end
+
+  describe '#allowed_action_names' do
+    subject(:allowed_action_names) { actions_policy_model.allowed_action_names }
+
+    it 'returns allowed actions' do
+      expect(allowed_action_names).to contain_exactly(:create, :read)
+    end
+  end
+end


### PR DESCRIPTION
Usage

```ruby
describe UserPolicy
  subject(:user_policy) { UserPolicy.new(user) }
  let(:user) { User.new }

  describe '#allowed_action_names'
    subject(:allowed_action_names) { policy.actions_policy.allowed_action_names }

    it 'allows correct actions' do
      expect(allowed_action_names).to contain_exactly(:create, :update)
    end
  end
end
```