### PR TITLE
Allow using proc style options for validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added: support for proc type validator options
 * Added/Changed/Deprecated/Removed/Fixed/Security: YOUR CHANGE HERE
 
 ## [1.1.0]

--- a/docs/components/action_validator.md
+++ b/docs/components/action_validator.md
@@ -6,7 +6,7 @@ The `ResourcePolicy::ActionValidator` is a validator used to check the policy of
 
 The `ResourcePolicy::ActionValidator` accepts two options:
 
-- `:allowed_to` (required) - Specifies the action type that needs to be checked. This can be a symbol or a string.
+- `:allowed_to` (required) - Specifies the action type that needs to be checked. This can be a symbol, string or proc.
 - `:as` (optional) - Specifies the key that will be used to display errors. This is useful if you want to rename the attribute being validated.
 
 ## Usage Example
@@ -31,4 +31,30 @@ else
 end
 ```
 
-In this example, the `SomeClass` has an attribute named `some_policy` which is being validated using the `ResourcePolicy::ActionValidator`. The validator checks if the create action is allowed using the SomePolicy object. If the action is not allowed, an error message will be added to the `record.errors` object with the key `:some_item`. If the `:as` option is not provided, the key used to display the error will be the name of the attribute being validated.
+## Usage Example with proc
+
+```ruby
+require 'resource_policy/action_validator'
+
+class SomeClass < ActiveRecord::Base
+  validates :some_policy, 'resource_policy/action': { allowed_to: -> { custom_allowed_to }, as: :some_item }
+
+  def some_policy
+    SomePolicy.new
+  end
+
+  def custom_allowed_to
+    new_record? ? :create : :update
+  end
+end
+
+new_object = SomeClass.new
+new_object.valid?
+new_object.errors.messages # => { some_item: ['action "create" is not allowed'] }
+
+existing_object = SomeClass.find(1)
+existing_object.valid?
+existing_object.errors.messages # => { some_item: ['action "update" is not allowed'] }
+```
+
+In this example, the `SomeClass` has an attribute named `some_policy` which is validated using the `ResourcePolicy::ActionValidator`. The validator calls `custom_allowed_to` method on our model to determine which action to use. If record is new, it will check policy for the `create` action. If the record saved, it will check policy for `update` action. When the action is not allowed, an error message will be added to the `record.errors` object with the key `:some_item`. If the `:as` option is not provided, the key used to display the error will be the name of the attribute being validated.

--- a/docs/components/attributes_validator.md
+++ b/docs/components/attributes_validator.md
@@ -7,7 +7,7 @@
 The validates method requires two options:
 
 - `:apply_to` (required) - The name of the method that returns the hash that needs to be validated.
-- `:allowed_to` (required) - The access level that we need to check. This can be either :read or :write.
+- `:allowed_to` (required) - The access level that we need to check. This can be Symbol, String or Proc.
 
 ## Usage example
 
@@ -35,3 +35,41 @@ end
 
 In this example, the `SomeClass` has an attribute named `some_policy` which is being validated using the `ResourcePolicy::AttributesValidator`. The validator checks if attributes from the `some_params` satisfy access level conditions (such as `:write`). It adds an error for each hash key that does not satisfy policy conditions.
 
+## Usage example using proc
+
+```ruby
+class SomeClass < ActiveRecord::Base
+  validates :some_policy, 'resource_policy/attributes': { apply_to: :some_params, allowed_to: -> { custom_allowed_to } }
+
+  def some_policy
+    SomePolicy.new
+  end
+
+  def some_params
+    { foo: :foo, bar: :bar }
+  end
+
+  def custom_allowed_to
+    new_record? :write : :change
+  end
+end
+
+some_object = SomeClass.new
+if some_object.valid?
+  # No validation errors, continue with the process
+else
+  some_object.errors.messages # => { foo: ['attribute action "write" is not allowed'], bar: ['attribute action "write" is not allowed'] }
+end
+
+new_object = SomeClass.new
+new_object.valid?
+new_object.errors.messages # => { foo: ['attribute action "write" is not allowed'], bar: ['attribute action "write" is not allowed'] }
+
+existing_object = SomeClass.find(1)
+existing_object.valid?
+existing_object.errors.messages # => { foo: ['attribute action "change" is not allowed'], bar: ['attribute action "change" is not allowed'] }
+```
+
+In this example, the `SomeClass` has an attribute named `some_policy` which is being validated using the `ResourcePolicy::AttributesValidator`. The validator checks if attributes from the `some_params` satisfy access level conditions (such as `:write`). It adds an error for each hash key that does not satisfy policy conditions.
+
+In this example, the `SomeClass` has an attribute named `some_policy` which is validated using the `ResourcePolicy::ActionValidator`. The validator calls `custom_allowed_to` method on our model to determine which access level to use. If record is new, it will check policy attributes for the `:write` access. If the record saved, it will check policy attributes for `:change` access level. It adds an error for each hash key that does not satisfy policy conditions.

--- a/lib/resource_policy/validators/attributes_validator.rb
+++ b/lib/resource_policy/validators/attributes_validator.rb
@@ -40,29 +40,40 @@ module ResourcePolicy
 
     def validate_attribute_policy(attribute_policy, record:, hash_attribute:)
       if attribute_policy.nil?
-        add_missing_policy_error_for(record, hash_attribute)
-      elsif !attribute_policy.allowed_to?(access_level)
-        add_not_permitted_error_for(record, hash_attribute)
+        return add_missing_policy_error_for(record, attribute: hash_attribute)
+      end
+
+      access_level = access_level_for(record)
+      if !attribute_policy.allowed_to?(access_level)
+        return add_not_permitted_error_for(record, attribute: hash_attribute)
       end
     end
 
-    def access_level
-      @access_level ||= options.fetch(:allowed_to)
+    def access_level_for(record)
+      fetch_option_value(:allowed_to, record: record)
     end
 
     def hash_value_for(record)
       record.send(options.fetch(:apply_to))
     end
 
-    def add_missing_policy_error_for(record, attribute)
+    def add_missing_policy_error_for(record, attribute:)
       record.errors.add(attribute, 'does not have attribute policy defined')
     end
 
-    def add_not_permitted_error_for(record, attribute)
+    def add_not_permitted_error_for(record, attribute:)
       record.errors.add(
         attribute,
-        "attribute action #{access_level.to_s.inspect} is not allowed"
+        "attribute action #{access_level_for(record).to_s.inspect} is not allowed"
       )
+    end
+
+    def fetch_option_value(key, record:, &block)
+      value = options.fetch(key, &block)
+
+      return record.instance_exec(&value) if value.is_a?(Proc)
+
+      value
     end
   end
 end

--- a/spec/lib/resource_policy/validators/action_validator_spec.rb
+++ b/spec/lib/resource_policy/validators/action_validator_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe ResourcePolicy::ActionValidator do
       Struct.new(:policy) do
         include ActiveModel::Validations
         validates :policy, 'resource_policy/action': { allowed_to: action, as: :user }
+
+        def custom_allowed_to
+          :create
+        end
       end
     end
 
@@ -59,6 +63,14 @@ RSpec.describe ResourcePolicy::ActionValidator do
         record.valid?
         expect(record.errors.messages)
           .to eq(user: ['does not have "does_not_exist" action policy defined'])
+      end
+    end
+
+    context 'when "allowed_to" is a proc' do
+      let(:action_type) { -> { custom_allowed_to } }
+
+      it 'keeps record valid' do
+        expect { record.valid? }.not_to change(record.errors, :count)
       end
     end
   end


### PR DESCRIPTION
Currently, `allowed_to:` option in validators is a fixed value, but there are cases when it's handy to have it as a dynamic value (for example as inheritance). 

This PR adds the possibility to pass some options as a proc:

```ruby
class SomeClass < ActiveRecord::Base
  validates :some_policy, 'resource_policy/action': { allowed_to: -> { custom_allowed_to }, as: :some_item }

  def some_policy
    SomePolicy.new
  end

  def custom_allowed_to
    new_record? ? :create : :update
  end
end
```